### PR TITLE
Fix tabs underline issue

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travis-builds-reporter-web-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "proxy": "http://localhost:3001/",
   "dependencies": {

--- a/client/src/components/AboutPage.jsx
+++ b/client/src/components/AboutPage.jsx
@@ -55,7 +55,7 @@ const About = () => (
           </TableRow>
           <TableRow>
             <TableRowColumn>travis-builds-reporter-web:frontend</TableRowColumn>
-            <TableRowColumn>0.1.1</TableRowColumn>
+            <TableRowColumn>0.1.2</TableRowColumn>
             <TableRowColumn><a href="https://github.com/niktekusho/travis-builds-reporter-web/tree/master/client">GitHub</a></TableRowColumn>
           </TableRow>
           <TableRow>

--- a/client/src/components/BuildsPage.jsx
+++ b/client/src/components/BuildsPage.jsx
@@ -22,7 +22,6 @@ export default class BuildsPage  extends React.Component {
   }
 
   handleChange = (value) => {
-    console.log(value);
     this.setState({
       index: value,
     });
@@ -52,7 +51,8 @@ export default class BuildsPage  extends React.Component {
             <p>
               <RaisedButton primary={true} onClick={() => handleBack()} label="Back"/>
             </p>
-            <Tabs index={index} onChange={this.handleChange}>
+            <div>
+            <Tabs value={index} onChange={this.handleChange}>
               <Tab label="Pretty"  value={0} />
               <Tab label="Table" value={1} />
               <Tab label="Graphs"  value={2} />
@@ -62,6 +62,7 @@ export default class BuildsPage  extends React.Component {
               <TableStats builds={builds} />
               <GraphStats builds={builds} />
             </SwipeableViews>
+            </div>
           </div>
         );
       }


### PR DESCRIPTION
When swiping with a touch enabled device the builds statistics component, the tab underline does not follow the correct tab. Attached is a screen recording demonstrating the issue

![nimbus-record-video-2017-07-18-14-39-47 2](https://user-images.githubusercontent.com/18280135/28317575-d5e91a8c-6bc7-11e7-9d1e-da694cbf041f.gif)
